### PR TITLE
Add a 'do not fork' warning, populate the older hackathons page, fix …

### DIFF
--- a/docs/01_getting_started/02_benchmarker/index.md
+++ b/docs/01_getting_started/02_benchmarker/index.md
@@ -1,15 +1,39 @@
 
 ## Benchmarker
 
-### Project setup with Omnibus
+Generating new benchmarks can be automated using:
 
-### Add metadata information to omni_essentials
+- [Project templates](https://github.com/omnibenchmark/contributed-project-templates), a semi-manual approach;
+- [omnibus](https://github.com/omnibenchmark/omnibus), a CLI-like experience using gitlab API calls to terraform new benchmarks.
 
-https://github.com/omnibenchmark/omni_essentials/blob/main/general/benchmark_categories.json
+### Setting up a benchmark with `omnibus`
 
-### Populating the benchmark
+After installing omnibus, docker and other requirements (such as defining a gitlab token so our user can create new projects via gitlab API), as described in [omnibus](https://github.com/omnibenchmark/omnibus), we need to define the benchmark structure. This is done via config files, and could be wrapped by using omnibus' wrapper:
 
-See `Module contributor`
+```
+source("R/create_config.R")
 
-### Setting up an orchestrator 
+create_config(
+	benchmark = "Your_benchmark",
+	config = "config_Your_benchmark",
+	datanames = c("name1", "name2", "name3"),
+	methodnames = c("name1", "name2"),
+	metricnames = c("name1", "name2"),
+	explainer = TRUE, # Adds explanation of each config parameter to the buttom of the file
+	... # Add any config parameter setting (does not work with BENCHMARK, REPONAMES,
+	# KEYWORDS, or TEMPLATES). Names must match the names from the template.
+	)
+# If you don't specific the config name, it will be called "config_<benchmark>".
 
+```
+
+Using this file, the command
+
+```
+omnibus -o -p -s -c CONFIGFILE
+
+```
+
+triggers the benchmark terraforming.
+
+To avoid storing the API token in clear text, you can pass it to `omnibus` with `--token TOKEN`.

--- a/docs/01_getting_started/03_method_user/index.md
+++ b/docs/01_getting_started/03_method_user/index.md
@@ -2,4 +2,11 @@
 
 # Benchmark outputs
 
-Available here: http://omnibenchmark.org/p/results/
+We provide benchmark outputs as datasets within each benchmark's gitlab modules.
+
+As for interactively browsing results, we provide [bettr](https://github.com/federicomarini/bettr) endpoints for all current benchmarks at [http://bettr.omnibenchmark.org/](https://bettr.omnibenchmark.org/) , including:
+
+- [https://bettr.omnibenchmark.org/DuoSCClustering2018/](https://bettr.omnibenchmark.org/DuoSCClustering2018/)
+- [https://bettr.omnibenchmark.org/iris/](https://bettr.omnibenchmark.org/iris/)
+- [https://bettr.omnibenchmark.org/omni_batch/](https://bettr.omnibenchmark.org/omni_batch/)
+- [https://bettr.omnibenchmark.org/omniclustering/](https://bettr.omnibenchmark.org/omniclustering/)

--- a/docs/02_advanced/01_module_contr/index.md
+++ b/docs/02_advanced/01_module_contr/index.md
@@ -1,4 +1,4 @@
 
 ## Advances topics for module contributor
 
-- The `omni_object` instance and its classes
+- The [omni_object](omni_object/index.md) instance and its classes

--- a/docs/02_advanced/04_admin/02_new_benchmark.md
+++ b/docs/02_advanced/04_admin/02_new_benchmark.md
@@ -121,4 +121,4 @@ Infrastructure-wise, some manual actions need to be done to start a new benchmar
 
 ### Runners
 
-It's advisable to register a dedicated gitlab runner when generating a benchmark, and use it as a group runner for CI/CD. For that, check [our runner's docs](04_runner).
+It's advisable to register a dedicated gitlab runner when generating a benchmark, and use it as a group runner for CI/CD. For that, check [our runner's docs](04_runner.md).

--- a/docs/02_advanced/04_admin/04_runner.md
+++ b/docs/02_advanced/04_admin/04_runner.md
@@ -47,7 +47,7 @@ sudo useradd --comment 'GitLab Runner' --create-home gitlab-runner --shell /bin/
 
 ## Register a gitlab runner in your (linux) machine 
 
-On GitLab Community Edition 14.10.5 (might sligthly vary within versions) visit your repository **or group of repositories**, i.e. [https://gitlab.renkulab.io/omb_benchmarks](this repository), go to `CI/CD` -> `Runners` (caution, not to `Settings -> CI/CD`, click `Register a group runner`, copy to the clipboard the registration token.
+On GitLab Community Edition 14.10.5 (might sligthly vary within versions) visit your repository **or group of repositories**, i.e. https://gitlab.renkulab.io/omb_benchmarks, go to `CI/CD` -> `Runners` (caution, not to `Settings -> CI/CD`, click `Register a group runner`, copy to the clipboard the registration token.
 
 Let's assume the token is `94daGGiXCgwthisisnotarealtoken`.
 

--- a/docs/02_advanced/index.md
+++ b/docs/02_advanced/index.md
@@ -1,10 +1,10 @@
 
 ## Advanced topics
 
-- **[Module contributor](01_module_contr)**: better control inputs, outputs and scripts. 
+- **[Module contributor](01_module_contr/index.md)**: better control inputs, outputs and scripts. 
 
-- **[Benchmarker](02_benchmarker)**: more complex designs and better control how your benchmark is run and populated.
+- **[Benchmarker](02_benchmarker/index.md)**: more complex designs and better control how your benchmark is run and populated.
 
-- **[Method user](03_method_user)**: download the results of a benchmark on your computer and wrangle the shiny app to your needs. 
+- **[Method user](03_method_user/index.md)**: download the results of a benchmark on your computer and wrangle the shiny app to your needs. 
 
-- **[Administrator](04_admin)**: guides to set up nonmandatory omnibenchmark components (i.e. your own gitlab runners, triplestore etc)
+- **[Administrator](04_admin/index.md)**: guides to set up nonmandatory omnibenchmark components (i.e. your own gitlab runners, triplestore etc)

--- a/docs/03_howto/01_build_object.md
+++ b/docs/03_howto/01_build_object.md
@@ -1,4 +1,3 @@
-(section-build-yaml)=
 
 # Build an OmniObject from yaml
 

--- a/docs/03_howto/02_create_dataset.md
+++ b/docs/03_howto/02_create_dataset.md
@@ -1,5 +1,3 @@
-(section-datasets)=
-
 # Datasets
 
 ## Generate Datasets

--- a/docs/03_howto/03_generate_workflow.md
+++ b/docs/03_howto/03_generate_workflow.md
@@ -1,3 +1,1 @@
-(section-workflow)=
-
 # Generate and update workflows

--- a/docs/03_howto/04_update_object.md
+++ b/docs/03_howto/04_update_object.md
@@ -1,3 +1,2 @@
-(section-update)=
 
 # Update OmniObject

--- a/docs/03_howto/index.md
+++ b/docs/03_howto/index.md
@@ -1,12 +1,17 @@
-
 ## How to's 
 
 ### Build object
 
+- [Objects](01_build_object.md)
+
 ### Create dataset
+
+- [Datasets](02_create_dataset.md)
 
 ### Generate workflow 
 
-### Update object
+- [Workflows](03_generate_workflow.md)
 
 ### Filter
+
+- [Filter parameters and inputs in objects](05_filter.md)

--- a/docs/05_events/BC2/hands-on_sessions.md
+++ b/docs/05_events/BC2/hands-on_sessions.md
@@ -31,6 +31,9 @@ You can find information about the required metadata (keywords, inputs, outputs,
 
 #### 1. Copy the structure of existing modules
 
+!!! warning
+    Please do not fork those to avoid transferring unintended metadata from the original project; rather, copy the module structure manually
+
 - [Example Dataset](https://gitlab.renkulab.io/omb_benchmarks/omniclustering/dataset_Koh_clustering)
 
 - [Example Method](https://gitlab.renkulab.io/omb_benchmarks/omniclustering/method_FlowSOM_clustering)
@@ -63,4 +66,4 @@ where  `BENCHMARK_NAME` is the name of the benchmark (`omniclustering`) and `STE
 
 An overview of the **Omnibenchmark components** is available on the [Omnibenchmark webpage](http://omnibenchmark.org/p/benchmarks/)
 
-The **output** of the benchmark is available on our [shiny app server](http://imlspenticton.uzh.ch:3840/omniclustering/)
+The **output** of the benchmark is available on our [shiny app server](https://bettr.omnibenchmark.org/omniclustering/).

--- a/docs/05_events/BC2/presentations.md
+++ b/docs/05_events/BC2/presentations.md
@@ -5,4 +5,6 @@
 
 - [Technical details (Anthony Sonrel)](https://docs.google.com/presentation/d/1KRJs_Md5BNwgLrcWKBnsB9cG18AS9jPF_RVAS32AUAc/edit?usp=sharing)
 
+- [Technical details (Almut Lütge)](https://slides.com/almutluetge/minimal-e178cf)
+
 - [Intro to clustering Omnibenchmark (Charlotte Soneson)](https://docs.google.com/presentation/d/1GKiHKmOE9m7w1cy6Et9CbmYMaK4l10CzsKyxtYVYKwI/edit#slide=id.p)

--- a/docs/05_events/robinsons_hackathons.md
+++ b/docs/05_events/robinsons_hackathons.md
@@ -1,0 +1,5 @@
+## Omnibenchmark hackathons
+
+### September 2022
+
+- [Working document](https://docs.google.com/document/d/1n9rYwYoORTrS8q5QcprjR1fCJArevNUvCX1uS-2c8eo/edit#)


### PR DESCRIPTION
- add a 'do not fork' warning to the BC2 hands on session
- populate the older hackathons page
- update bettR endpoint to omnibenchmark.org's
- fix warnings